### PR TITLE
feat: re-add claude alias and JavaScript tools

### DIFF
--- a/machines/modules/users/tghanken/home-manager.nix
+++ b/machines/modules/users/tghanken/home-manager.nix
@@ -70,6 +70,11 @@
     zstd
     gnupg
 
+    # Javascript
+    nodejs
+    pnpm
+    bun
+
     # nix related
     #
     # it provides the command `nom` works just like `nix`
@@ -161,6 +166,7 @@
       gitprune = "git fetch -p ; git branch -r | awk '{print $1}' | egrep -v -f /dev/fd/0 <(git branch -vv | grep origin) | awk '{print $1}' | xargs git branch -D";
       gitsync = "git checkout main; git pull; gitprune;";
       windsurf = "nix run github:tghanken/nixos-config#windsurf";
+      claude = "bunx @anthropic-ai/claude-code";
     };
   };
 


### PR DESCRIPTION
## Summary
- Re-add claude alias that runs `bunx @anthropic-ai/claude-code`
- Add JavaScript development tools: nodejs, pnpm, bun

## Test plan
- [ ] Verify the claude alias works correctly
- [ ] Confirm JavaScript tools are available after rebuild

🤖 Generated with [Claude Code](https://claude.ai/code)