### PR TITLE
feat: GitHub Actions runners on hercules

### DIFF
--- a/nix/hosts/hercules/configuration.nix
+++ b/nix/hosts/hercules/configuration.nix
@@ -24,6 +24,9 @@
     flake.modules.profiles.ai
     flake.modules.profiles.development
     flake.modules.profiles.gaming
+
+    # GitHub Actions runner container
+    flake.modules.utils.github-runner
   ];
 
   # Required for nixos-anywhere
@@ -32,4 +35,23 @@
   networking.hostId = "c1c4e9e4"; # Generate using `head -c 8 /etc/machine-id`
 
   system.stateVersion = "25.11"; # initial nixos state
+
+  services.github-runner-containers = {
+    enable = true;
+    runners = [
+      {
+        owner = "tghanken";
+        repo = "nixos-config";
+      }
+      {
+        owner = "tghanken";
+        repo = "seneschal";
+      }
+      {
+        owner = "actionable-work";
+        repo = "actionable";
+      }
+    ];
+    extraLabels = ["nixos"];
+  };
 }

--- a/nix/modules/secrets/secret_files/encrypted/github_runner_actionable_work.age
+++ b/nix/modules/secrets/secret_files/encrypted/github_runner_actionable_work.age
@@ -1,0 +1,13 @@
+age-encryption.org/v1
+-> ssh-ed25519 hbhB2A nJrPYUPhRe5fy6usY3+MK5Hvx40ppduU8lyq6Zx3RnE
+3aU6e5qYfeEQe2DV4VR3025qTSJI34CproPIzE2TWiM
+-> ssh-ed25519 zFIqbQ Vw9dZlJcHDyA3IBSTV1+Fzvo7XQKU3v66vbieaFAlwA
+ZGf5uw7nXsVZebEXSP6oVViVUUemQ+D7K3i6QRS0YQc
+-> ssh-ed25519 D+NVRg vIEWp541ioUGBSQna3JyceT83uxvVRP3LjfPDNGlu2s
+6jTmCBlfFPtRH7CmgCVLSZ26+49E1W7AAWF4WIDYo7Y
+-> ssh-ed25519 BEMHQg KJZxFinyFuPdvL/1/wzxy1I0u3tBbUEWlthfMMVqujY
+2dR41zq2Qku+/YglBR0gT398Aw7jySuCEPTQw/KHEwA
+-> ssh-ed25519 YDKZOA cubuYbFFLSRtAZ9LV54CdIEh9h5aQGiOmTtXIwi6g3g
+DF7sh+BNo+nBu0AybLBIL9tT7eLbcG3QGqdTCrovArA
+--- jRZ0cdLaWU27I/Tsw/qcMzSf+j+y7LAvNPA/dP7eAUw
+‹#"ЭњD‰~TF‰OћЧџв)N‰абM{8=µую&ouЈ6uPш0Щ‘Яzж•kЪИHМ>M(^A?†ДaСLdЈЁЖыP9пAЏ1ЙёЯй!Gв»ч(3І„¬-У¶¬ёЩ®\јё–І7ЕіqK3r! И‚Ъ

--- a/nix/modules/secrets/secret_files/encrypted/github_runner_tghanken.age
+++ b/nix/modules/secrets/secret_files/encrypted/github_runner_tghanken.age
@@ -1,0 +1,13 @@
+age-encryption.org/v1
+-> ssh-ed25519 hbhB2A d5l4ken4na64CTG4wf75QRIifqUaS3TSPABcpXIthAY
+7RF2q+iuWTDUs2kw2pQzwioUM37Ej6gyua9QsAfPBLk
+-> ssh-ed25519 zFIqbQ kAnSHbWsrzO8XVPRtvkaQ7vMChPqaY8UBTO6NZ7ren4
+cbLwFqdpt0pcsbszqYl9tXrEHDcmB2L/2p/83BA8z08
+-> ssh-ed25519 D+NVRg rvyEuP66Sx1rPP0C2n4iVkGqwekOSlZf1PWLOJtCGQc
+ryztylNC1uxujbqDwcMcwOPvysxVniPvwoHai/MGNls
+-> ssh-ed25519 BEMHQg XR5wNXRN2jONSE5Onc5m57Cxpz4KAmUeqACllTDEKRM
+j7R1XvC0ehvyt/i8FdQq1L8yRTsk54rmHKc8sO6fccc
+-> ssh-ed25519 YDKZOA 3Ddo55JIftlb4NQbu6YISjLQ+Q3TEZiwDesaVPQPBkw
+OlahKGzv5TxDIbyXkich3DM6WJmQQ2KGLPsm8kOYhUo
+--- /PpF/8+cRBbc0NQHXhO3HMjdUkq/EAnDB9Z8VtOjaDM
+-jâQ	6ÎÁq—Û¼>ëÕ;–1®?ñ@µ£^$/IÚPKN<sñ¹¼‹ü¡~‹JŸ dPÄUTáÍˆÌ£0ÕZ!Üß•uùÿãçŽÞqs£L¥8ÿËÊÖ›qrÆébA¶F>dQej]YÔB9jwÝ~8¨3ËwŠ]Ä

--- a/nix/modules/secrets/secret_files/secrets.nix
+++ b/nix/modules/secrets/secret_files/secrets.nix
@@ -11,4 +11,6 @@ in {
   # "encrypted/netbird_remote_server.age".publicKeys = keys.remote-servers ++ keys.tghanken;
   "encrypted/nix_store_signing_key.age".publicKeys = keys.all;
   "encrypted/tailscale_key.age".publicKeys = keys.all;
+  "encrypted/github_runner_tghanken.age".publicKeys = [keys.hercules] ++ keys.tghanken;
+  "encrypted/github_runner_actionable_work.age".publicKeys = [keys.hercules] ++ keys.tghanken;
 }

--- a/nix/modules/utils/github-runner.md
+++ b/nix/modules/utils/github-runner.md
@@ -1,0 +1,145 @@
+# GitHub Actions runners on NixOS
+
+Self-hosted runners for hercules (and any host that imports
+`flake.modules.utils.github-runner`).
+
+## Layout
+
+- **One NixOS container per GitHub owner** (`tghanken`, `actionable-work`, …)
+- **One agenix PAT per owner** — mounted only into that owner's container
+- **One `services.github-runners` unit per repository** inside the owner container
+
+Example on hercules:
+
+| Container | PAT secret | Repos |
+|---|---|---|
+| `github-runners-tghanken` | `github_runner_tghanken.age` | `nixos-config`, `seneschal` |
+| `github-runners-actionable-work` | `github_runner_actionable_work.age` | `actionable` |
+
+Shared with the host (by design): read-only `/nix/store`, nix-daemon socket,
+and (optionally) the Docker socket. Isolation is for **tokens / runner state**,
+not for build sandboxing.
+
+## Authentication: what to use
+
+The nixpkgs `services.github-runners` module accepts a file containing either:
+
+1. **Fine-grained PAT** (recommended)
+2. **Classic PAT**
+3. **Runner registration token** (not recommended — expires in ~1 hour)
+
+There is **no first-class GitHub App support** in the module today. A GitHub App
+is nicer long-term (short-lived tokens, org install, no user-owned secret), but
+you would need a small wrapper that mints a registration token into the
+`tokenFile` before the runner starts. Until then, use fine-grained PATs.
+
+Registration tokens from the “Add runner” UI are a bad fit for NixOS: any
+reconfigure after expiry fails with opaque `404`s.
+
+## Fine-grained PAT (recommended)
+
+Create one PAT **per owner** (Settings → Developer settings → Fine-grained tokens,
+or org → Settings → Personal access tokens if using an org-owned token).
+
+### Resource owner
+
+- Personal repos: your user (`tghanken`)
+- Org repos: the organization (`actionable-work`)
+
+### Repository access
+
+- **Only select repositories** you register runners for  
+  (e.g. `nixos-config` + `seneschal`, or `actionable`)
+
+### Permissions
+
+Under **Repository permissions**:
+
+| Permission | Access | Why |
+|---|---|---|
+| **Administration** | Read and write | Required to create/manage self-hosted runners on the repo |
+
+That is the permission GitHub exposes for “repository self-hosted runners”.
+nixpkgs documents it as *Read and Write access to … repository self hosted runners*;
+in the fine-grained UI this maps to **Administration** (not the separate Actions
+permission).
+
+If Administration alone fails registration, also try:
+
+| Permission | Access |
+|---|---|
+| **Actions** | Read and write |
+| **Metadata** | Read-only (usually required / auto-included) |
+
+### Org-wide runners (optional)
+
+If you later register at `https://github.com/<org>` instead of per-repo URLs:
+
+- Resource owner = organization
+- Repository access = **All repositories** (or the set you care about)
+- Organization permissions: **Self-hosted runners** → Read and write
+
+This module currently uses **per-repo** registration URLs, so repo Administration
+on the listed repos is enough.
+
+### Token file format
+
+Exactly one line, **no trailing newline**:
+
+```bash
+# create / update the agenix secret (opens $EDITOR)
+just es github_runner_tghanken
+# paste the token with no newline, or from a file:
+# printf '%s' "$TOKEN" | … into the editor buffer
+```
+
+Secret names (hyphens → underscores):
+
+- `encrypted/github_runner_tghanken.age`
+- `encrypted/github_runner_actionable_work.age`
+
+Public keys for those secrets are in `nix/modules/secrets/secret_files/secrets.nix`
+(hercules host key + your user keys).
+
+## Classic PAT (fallback)
+
+| Use case | Classic scope |
+|---|---|
+| User/repo runners | `repo` |
+| Org-wide runners | `admin:org` |
+
+Prefer fine-grained tokens; classic scopes are broader than needed.
+
+## Labels / `runs-on`
+
+Default labels from GitHub: `self-hosted`, `Linux`, `X64`.  
+This module also adds `nixos` and the hostname (e.g. `hercules`).
+
+```yaml
+jobs:
+  build:
+    runs-on: [self-hosted, nixos, hercules]
+```
+
+Do not add a redundant `linux` label.
+
+## Deploy checklist
+
+1. Create the two fine-grained PATs with the scopes above
+2. `just es github_runner_tghanken` and `just es github_runner_actionable_work`
+3. Deploy hercules
+4. Confirm containers: `machinectl list` → `github-runners-tghanken`, `github-runners-actionable_work`
+5. Confirm runners under each repo’s **Settings → Actions → Runners**
+
+## Adding a repo
+
+```nix
+services.github-runner-containers.runners = [
+  # …
+  { owner = "tghanken"; repo = "new-repo"; }
+];
+```
+
+If the owner is new, add `encrypted/github_runner_<owner>.age` to `secrets.nix`
+and create the PAT/secret. If the owner already exists, extend that owner’s
+fine-grained PAT repository list to include the new repo.

--- a/nix/modules/utils/github-runner.md
+++ b/nix/modules/utils/github-runner.md
@@ -16,9 +16,11 @@ Example on hercules:
 | `github-runners-tghanken` | `github_runner_tghanken.age` | `nixos-config`, `seneschal` |
 | `github-runners-actionable-work` | `github_runner_actionable_work.age` | `actionable` |
 
-Shared with the host (by design): read-only `/nix/store`, nix-daemon socket,
-and (optionally) the Docker socket. Isolation is for **tokens / runner state**,
-not for build sandboxing.
+Shared with the host (by design): read-only `/nix/store`, read-only nix-daemon
+socket, and (optionally) the Docker socket. Containers **do not** run their own
+`nix-daemon` when store sharing is enabled — a second daemon on the shared
+socket would replace the host socket and break Nix for the whole machine.
+Isolation is for **tokens / runner state**, not for build sandboxing.
 
 ## Authentication: what to use
 

--- a/nix/modules/utils/github-runner.nix
+++ b/nix/modules/utils/github-runner.nix
@@ -92,9 +92,10 @@ top@{
           hostPath = "/nix/store";
           isReadOnly = true;
         };
+        # Read-only so the container cannot replace the host's daemon socket.
         "/nix/var/nix/daemon-socket" = {
           hostPath = "/nix/var/nix/daemon-socket";
-          isReadOnly = false;
+          isReadOnly = true;
         };
       };
 
@@ -111,6 +112,14 @@ top@{
 
       programs.nix-ld.enable = true;
 
+      # Never run a container-local nix-daemon against the shared host socket —
+      # that replaces the host socket and breaks Nix for everyone on the machine.
+      nix.enable = !cfg.shareNixStore;
+      environment.systemPackages = optionals cfg.shareNixStore [pkgs.nix];
+      environment.variables = optionalAttrs cfg.shareNixStore {
+        NIX_REMOTE = "daemon";
+      };
+
       nix.settings = mkMerge [
         {
           experimental-features = [
@@ -118,7 +127,6 @@ top@{
             "flakes"
           ];
           trusted-users = [runnerUser];
-          allowed-users = [runnerUser];
           keep-outputs = true;
           keep-derivations = true;
         }
@@ -210,9 +218,9 @@ in {
       type = types.bool;
       default = true;
       description = ''
-        Bind-mount the host `/nix/store` (read-only) and nix-daemon socket into
-        each container, and set `NIX_REMOTE=daemon` so builds reuse the host
-        store and daemon.
+        Bind-mount the host `/nix/store` (read-only) and nix-daemon socket
+        (read-only) into each container, disable the in-container nix-daemon,
+        and set `NIX_REMOTE=daemon` so builds reuse the host store and daemon.
       '';
     };
 
@@ -269,10 +277,11 @@ in {
       ];
 
       # Host daemon performs substitutions when shareNixStore is on.
+      # trusted-users implies allowed; do not set allowed-users (would risk
+      # narrowing access if merged incorrectly).
       nix.settings = mkMerge [
         {
           trusted-users = [runnerUser];
-          allowed-users = [runnerUser];
         }
         (mkIf cfg.niks3.enable {
           substituters = [cfg.niks3.substituter];

--- a/nix/modules/utils/github-runner.nix
+++ b/nix/modules/utils/github-runner.nix
@@ -1,0 +1,299 @@
+/*
+  GitHub Actions self-hosted runners: one NixOS container per GitHub owner.
+
+  Each owner gets its own container and agenix PAT so tokens are not shared
+  across personal vs org boundaries. See github-runner.md for auth setup.
+
+    just es github_runner_<owner>
+
+  Token file must be exactly one line with no trailing newline.
+*/
+top@{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib) types mkOption mkIf mkMerge listToAttrs nameValuePair optionalAttrs optionals unique groupBy mapAttrsToList;
+  cfg = config.services.github-runner-containers;
+
+  runnerUser = "github-runner";
+  encryptedPath = ../secrets/secret_files/encrypted;
+
+  sanitizeSecret = s: lib.replaceStrings ["-" "."] ["_" "_"] s;
+  # nixos-containers disallow underscores in names
+  sanitizeContainer = s: lib.replaceStrings ["_" "."] ["-" "-"] s;
+  secretNameForOwner = owner: "github_runner_${sanitizeSecret owner}";
+  containerNameForOwner = owner: "github-runners-${sanitizeContainer owner}";
+  runnerServiceName = runner: "${sanitizeSecret runner.owner}-${sanitizeSecret runner.repo}";
+  runnerUrl = runner: "https://github.com/${runner.owner}/${runner.repo}";
+
+  owners = unique (map (r: r.owner) cfg.runners);
+  runnersByOwner = groupBy (r: r.owner) cfg.runners;
+
+  niks3Substituter = "https://niks3.actionable-internal.work";
+  niks3PublicKey = "actionable-niks3:A3EpGS6+W9zj0r6tY3KPoODoBRELq70j+dkbhhgi7aQ=";
+
+  hostDockerGid = config.users.groups.docker.gid or null;
+  hostName = config.networking.hostName;
+
+  userModule = {
+    users.users.${runnerUser} = {
+      isSystemUser = true;
+      group = runnerUser;
+      description = "GitHub Actions runner";
+      extraGroups = optionals cfg.dockerSocket ["docker"];
+    };
+    users.groups.${runnerUser} = {};
+  };
+
+  runnerSubmodule = types.submodule {
+    options = {
+      owner = mkOption {
+        type = types.str;
+        description = "GitHub owner (user or organization).";
+        example = "tghanken";
+      };
+      repo = mkOption {
+        type = types.str;
+        description = "Repository name.";
+        example = "nixos-config";
+      };
+      extraLabels = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = "Extra labels for this runner (merged with module defaults).";
+      };
+    };
+  };
+
+  mkOwnerContainer = owner: runners: let
+    tokenFile = config.age.secrets.${secretNameForOwner owner}.path;
+  in {
+    autoStart = true;
+    ephemeral = false;
+    privateUsers = "no";
+
+    bindMounts =
+      {
+        ${tokenFile} = {
+          hostPath = tokenFile;
+          isReadOnly = true;
+        };
+      }
+      // optionalAttrs cfg.dockerSocket {
+        "/var/run/docker.sock" = {
+          hostPath = "/var/run/docker.sock";
+          isReadOnly = false;
+        };
+      }
+      // optionalAttrs cfg.shareNixStore {
+        "/nix/store" = {
+          hostPath = "/nix/store";
+          isReadOnly = true;
+        };
+        "/nix/var/nix/daemon-socket" = {
+          hostPath = "/nix/var/nix/daemon-socket";
+          isReadOnly = false;
+        };
+      };
+
+    config = {
+      pkgs,
+      lib,
+      ...
+    }: {
+      imports = [userModule];
+
+      system.stateVersion = top.config.system.stateVersion;
+
+      networking.hostName = containerNameForOwner owner;
+
+      programs.nix-ld.enable = true;
+
+      nix.settings = mkMerge [
+        {
+          experimental-features = [
+            "nix-command"
+            "flakes"
+          ];
+          trusted-users = [runnerUser];
+          allowed-users = [runnerUser];
+          keep-outputs = true;
+          keep-derivations = true;
+        }
+        (mkIf cfg.niks3.enable {
+          substituters = [cfg.niks3.substituter];
+          trusted-public-keys = [cfg.niks3.publicKey];
+        })
+      ];
+
+      users.groups.docker = mkIf cfg.dockerSocket (
+        mkIf (hostDockerGid != null) {
+          gid = hostDockerGid;
+        }
+      );
+
+      services.github-runners = listToAttrs (
+        map (runner: let
+          labels =
+            cfg.extraLabels
+            ++ [hostName]
+            ++ runner.extraLabels;
+        in
+          nameValuePair (runnerServiceName runner) {
+            enable = true;
+            name = "${runner.owner}-${runner.repo}-${hostName}";
+            url = runnerUrl runner;
+            inherit (cfg) extraPackages;
+            user = runnerUser;
+            group = runnerUser;
+            tokenFile = tokenFile;
+            replace = true;
+            extraLabels = labels;
+            extraEnvironment = optionalAttrs cfg.shareNixStore {
+              NIX_REMOTE = "daemon";
+            };
+            serviceOverrides = {
+              PrivateUsers = false;
+              RestrictNamespaces = false;
+              SupplementaryGroups = optionals cfg.dockerSocket ["docker"];
+              BindPaths =
+                (optionals cfg.dockerSocket ["/var/run/docker.sock"])
+                ++ (optionals cfg.shareNixStore ["/nix/var/nix/daemon-socket"]);
+              BindReadOnlyPaths = optionals cfg.shareNixStore ["/nix/store"];
+            };
+          })
+        runners
+      );
+    };
+  };
+in {
+  options.services.github-runner-containers = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Run GitHub Actions self-hosted runners in per-owner NixOS containers.";
+    };
+
+    runners = mkOption {
+      type = types.listOf runnerSubmodule;
+      default = [];
+      description = ''
+        Runners to register. Grouped by `owner` into one container each.
+        Each owner needs encrypted/github_runner_<owner>.age
+        (hyphens/dots become underscores). See github-runner.md.
+      '';
+      example = [
+        {
+          owner = "tghanken";
+          repo = "nixos-config";
+        }
+        {
+          owner = "actionable-work";
+          repo = "actionable";
+        }
+      ];
+    };
+
+    dockerSocket = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Bind-mount the host Docker socket into runner containers so workflows
+        can use `container:` jobs. Weakens isolation: jobs can control the
+        host Docker daemon.
+      '';
+    };
+
+    shareNixStore = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Bind-mount the host `/nix/store` (read-only) and nix-daemon socket into
+        each container, and set `NIX_REMOTE=daemon` so builds reuse the host
+        store and daemon.
+      '';
+    };
+
+    extraLabels = mkOption {
+      type = types.listOf types.str;
+      default = ["nixos"];
+      description = "Extra runner labels applied to every runner (plus hostname).";
+    };
+
+    extraPackages = mkOption {
+      type = types.listOf types.package;
+      default = with pkgs; [
+        git
+        which
+        coreutils
+        docker
+        cachix
+      ];
+      description = "Packages available to GitHub Actions jobs on the runner.";
+    };
+
+    niks3 = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Add the actionable niks3 binary cache as a pull-only substituter.";
+      };
+      substituter = mkOption {
+        type = types.str;
+        default = niks3Substituter;
+        description = "niks3 substituter URL.";
+      };
+      publicKey = mkOption {
+        type = types.str;
+        default = niks3PublicKey;
+        description = "niks3 trusted public key.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    userModule
+
+    {
+      assertions = [
+        {
+          assertion = cfg.runners != [];
+          message = "services.github-runner-containers.runners must be non-empty when enable = true";
+        }
+        {
+          assertion = !cfg.dockerSocket || config.virtualisation.docker.enable;
+          message = "services.github-runner-containers.dockerSocket requires virtualisation.docker.enable";
+        }
+      ];
+
+      # Host daemon performs substitutions when shareNixStore is on.
+      nix.settings = mkMerge [
+        {
+          trusted-users = [runnerUser];
+          allowed-users = [runnerUser];
+        }
+        (mkIf cfg.niks3.enable {
+          substituters = [cfg.niks3.substituter];
+          trusted-public-keys = [cfg.niks3.publicKey];
+        })
+      ];
+
+      age.secrets = listToAttrs (
+        map (owner:
+          nameValuePair (secretNameForOwner owner) {
+            file = "${encryptedPath}/${secretNameForOwner owner}.age";
+            mode = "0440";
+          })
+        owners
+      );
+
+      containers = listToAttrs (
+        mapAttrsToList (owner: runners:
+          nameValuePair (containerNameForOwner owner) (mkOwnerContainer owner runners))
+        runnersByOwner
+      );
+    }
+  ]);
+}


### PR DESCRIPTION
## Summary
- Add a NixOS module that runs self-hosted GitHub Actions runners in per-owner containers on hercules (`tghanken` and `actionable-work`)
- Share the host nix store/daemon and pull-only niks3 substituter to cut rebuilds; optional host Docker socket for `container:` jobs
- Document fine-grained PAT permissions and wire owner-scoped agenix secrets

## Test plan
- [ ] Confirm `github_runner_tghanken.age` / `github_runner_actionable_work.age` decrypt on hercules
- [ ] `nh os test` (or switch) on hercules succeeds
- [ ] `machinectl list` shows `github-runners-tghanken` and `github-runners-actionable-work`
- [ ] Runners appear under each repo’s Settings → Actions → Runners
- [ ] A workflow with `runs-on: [self-hosted, nixos, hercules]` is picked up