### PR TITLE
fix: resolve flake check warnings and issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ result-*
 # Ignore automatically generated direnv output
 .direnv
 
+# jj / git workspaces
+.worktrees/
+
 # Beads / Dolt files (added by bd init)
 .dolt/
 *.db

--- a/flake.lock
+++ b/flake.lock
@@ -446,29 +446,6 @@
         "type": "github"
       }
     },
-    "nixos-generators": {
-      "inputs": {
-        "nixlib": [
-          "nixpkgs-lib"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769813415,
-        "narHash": "sha256-nnVmNNKBi1YiBNPhKclNYDORoHkuKipoz7EtVnXO50A=",
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "rev": "8946737ff703382fda7623b9fab071d037e897d5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "type": "github"
-      }
-    },
     "nixos-hardware": {
       "inputs": {
         "nixpkgs": [
@@ -621,7 +598,6 @@
         "nix-fast-build": "nix-fast-build",
         "nixos-anywhere": "nixos-anywhere",
         "nixos-facter-modules": "nixos-facter-modules",
-        "nixos-generators": "nixos-generators",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_2",
         "nixpkgs-lib": "nixpkgs-lib",

--- a/flake.nix
+++ b/flake.nix
@@ -62,11 +62,6 @@
     nixos-facter-modules = {
       url = "github:numtide/nixos-facter-modules";
     };
-    nixos-generators = {
-      url = "github:nix-community/nixos-generators";
-      inputs.nixlib.follows = "nixpkgs-lib";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
     nixos-hardware = {
       url = "github:NixOS/nixos-hardware";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -90,11 +85,27 @@
   };
 
   # Load the blueprint
-  outputs = inputs:
-    inputs.blueprint {
+  outputs = inputs: let
+    blueprint = inputs.blueprint {
       inherit inputs;
       prefix = "nix/";
       # Only support systems that have at least one host
       systems = ["x86_64-linux"];
+    };
+
+    # Blueprint leaves modules that take args beyond flake/inputs as store
+    # paths. `nix flake check` requires nixosModules/homeModules to be
+    # functions or attrsets, so import those leftovers only (do not remap
+    # blueprint.modules — duplicate imports break option uniqueness).
+    ensureModule = module:
+      if builtins.isPath module || builtins.isString module
+      then import module
+      else module;
+    mapModules = builtins.mapAttrs (_: ensureModule);
+  in
+    blueprint
+    // {
+      nixosModules = mapModules blueprint.nixosModules;
+      homeModules = mapModules blueprint.homeModules;
     };
 }

--- a/nix/modules/home/development.nix
+++ b/nix/modules/home/development.nix
@@ -128,7 +128,7 @@ in {
 
   home.packages = with pkgs;
     [
-      unstable.antigravity-fhs
+      unstable.antigravity-ide-fhs
       unstable.code-cursor-fhs
       gh
       nil

--- a/nix/modules/profiles/bootstrap.nix
+++ b/nix/modules/profiles/bootstrap.nix
@@ -9,6 +9,7 @@
     {
       networking.hostId = "12345678";
       boot.supportedFilesystems = ["zfs"];
+      boot.zfs.forceImportRoot = false;
       system.stateVersion = "25.11";
     }
   ];

--- a/nix/modules/utils/github-runner.nix
+++ b/nix/modules/utils/github-runner.nix
@@ -1,14 +1,14 @@
 /*
-  GitHub Actions self-hosted runners: one NixOS container per GitHub owner.
+GitHub Actions self-hosted runners: one NixOS container per GitHub owner.
 
-  Each owner gets its own container and agenix PAT so tokens are not shared
-  across personal vs org boundaries. See github-runner.md for auth setup.
+Each owner gets its own container and agenix PAT so tokens are not shared
+across personal vs org boundaries. See github-runner.md for auth setup.
 
-    just es github_runner_<owner>
+  just es github_runner_<owner>
 
-  Token file must be exactly one line with no trailing newline.
+Token file must be exactly one line with no trailing newline.
 */
-top@{
+top @ {
   config,
   lib,
   pkgs,
@@ -99,11 +99,7 @@ top@{
         };
       };
 
-    config = {
-      pkgs,
-      lib,
-      ...
-    }: {
+    config = {pkgs, ...}: {
       imports = [userModule];
 
       system.stateVersion = top.config.system.stateVersion;

--- a/nix/packages/node-bootstrap-iso.nix
+++ b/nix/packages/node-bootstrap-iso.nix
@@ -2,17 +2,28 @@
   inputs,
   flake,
   ...
-}:
-inputs.nixos-generators.nixosGenerate {
+}: let
   system = "x86_64-linux";
-  format = "iso";
-  modules = [
-    flake.modules.profiles.bootstrap
-    flake.modules.users.tghanken
-    {
-      networking.hostId = "12345678";
-      boot.supportedFilesystems = ["zfs"];
-      system.stateVersion = "25.11";
-    }
-  ];
-}
+  nixos = inputs.nixpkgs.lib.nixosSystem {
+    inherit system;
+    specialArgs = {inherit inputs flake;};
+    modules = [
+      (
+        {modulesPath, ...}: {
+          imports = ["${modulesPath}/installer/cd-dvd/iso-image.nix"];
+          isoImage.makeEfiBootable = true;
+          isoImage.makeUsbBootable = true;
+        }
+      )
+      flake.modules.profiles.bootstrap
+      flake.modules.users.tghanken
+      {
+        networking.hostId = "12345678";
+        boot.supportedFilesystems = ["zfs"];
+        boot.zfs.forceImportRoot = false;
+        system.stateVersion = "25.11";
+      }
+    ];
+  };
+in
+  nixos.config.system.build.isoImage


### PR DESCRIPTION
## Summary
- Fix `nix flake check` failures by importing Blueprint path leftovers for `nixosModules`/`homeModules` (`isFunctionOrAttrs`)
- Replace deprecated `nixos-generators` with nixpkgs `iso-image`, set `boot.zfs.forceImportRoot = false` on bootstrap/ISO, and rename `antigravity-fhs` → `antigravity-ide-fhs`
- Also includes the hercules GitHub Actions runner containers work this branch was based on (runners module, secrets, host wiring) plus treefmt cleanup on `github-runner.nix`

## Test plan
- [x] `nix flake check path:. --all-systems` passes (all checks green; no evaluation warnings)
- [ ] Confirm hercules runner docs/module still match intended deploy steps
- [ ] After merge, spot-check `nix build .#packages.x86_64-linux.node-bootstrap-iso` still evaluates