### PR TITLE
feat: replace garnix with GitHub Actions flake-check

### DIFF
--- a/.github/workflows/cron_workflows.yml
+++ b/.github/workflows/cron_workflows.yml
@@ -6,17 +6,10 @@ on:
 jobs:
   lockfile:
     name: 🔒 Update flake.lock
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, nixos]
     steps:
       - name: 🖥️ Checkout git branch
-        uses: actions/checkout@v4
-      - name: 🦾 Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-        with:
-          determinate: true
-          extra-conf: |
-            substituters = https://nix-community.cachix.org https://cache.garnix.io https://cache.nixos.org/
-            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g=
+        uses: actions/checkout@v5
       - name: 🎟 Get GitHub App token
         uses: navikt/github-app-token-generator@b96ff604b2300989cd1105e3fad09199fca56681
         id: get-token

--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -1,0 +1,19 @@
+name: flake-check
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+permissions:
+  contents: read
+jobs:
+  flake-check:
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+    runs-on: [self-hosted, nixos]
+    concurrency:
+      group: flake-check-${{ github.ref == 'refs/heads/main' && 'main' || github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v5
+      - name: flake-check
+        run: nix run .#flake-check

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ result-*
 # Ignore automatically generated direnv output
 .direnv
 
+# jj / git workspaces
+.worktrees/
+
 # Beads / Dolt files (added by bd init)
 .dolt/
 *.db

--- a/flake.lock
+++ b/flake.lock
@@ -446,29 +446,6 @@
         "type": "github"
       }
     },
-    "nixos-generators": {
-      "inputs": {
-        "nixlib": [
-          "nixpkgs-lib"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769813415,
-        "narHash": "sha256-nnVmNNKBi1YiBNPhKclNYDORoHkuKipoz7EtVnXO50A=",
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "rev": "8946737ff703382fda7623b9fab071d037e897d5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "type": "github"
-      }
-    },
     "nixos-hardware": {
       "inputs": {
         "nixpkgs": [
@@ -621,7 +598,6 @@
         "nix-fast-build": "nix-fast-build",
         "nixos-anywhere": "nixos-anywhere",
         "nixos-facter-modules": "nixos-facter-modules",
-        "nixos-generators": "nixos-generators",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_2",
         "nixpkgs-lib": "nixpkgs-lib",

--- a/flake.nix
+++ b/flake.nix
@@ -62,11 +62,6 @@
     nixos-facter-modules = {
       url = "github:numtide/nixos-facter-modules";
     };
-    nixos-generators = {
-      url = "github:nix-community/nixos-generators";
-      inputs.nixlib.follows = "nixpkgs-lib";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
     nixos-hardware = {
       url = "github:NixOS/nixos-hardware";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -90,11 +85,27 @@
   };
 
   # Load the blueprint
-  outputs = inputs:
-    inputs.blueprint {
+  outputs = inputs: let
+    blueprint = inputs.blueprint {
       inherit inputs;
       prefix = "nix/";
       # Only support systems that have at least one host
       systems = ["x86_64-linux"];
+    };
+
+    # Blueprint leaves modules that take args beyond flake/inputs as store
+    # paths. `nix flake check` requires nixosModules/homeModules to be
+    # functions or attrsets, so import those leftovers only (do not remap
+    # blueprint.modules — duplicate imports break option uniqueness).
+    ensureModule = module:
+      if builtins.isPath module || builtins.isString module
+      then import module
+      else module;
+    mapModules = builtins.mapAttrs (_: ensureModule);
+  in
+    blueprint
+    // {
+      nixosModules = mapModules blueprint.nixosModules;
+      homeModules = mapModules blueprint.homeModules;
     };
 }

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,6 +1,0 @@
-builds:
-  exclude: []
-  include:
-    - 'checks.*.*'
-    - 'nixosConfigurations.*'
-    - 'packages.*.*'

--- a/nix/lib/flake-check-tier.nix
+++ b/nix/lib/flake-check-tier.nix
@@ -1,0 +1,111 @@
+{
+  pkgs,
+  flakeSrc,
+  name,
+}:
+pkgs.writeShellApplication {
+  inherit name;
+  runtimeInputs = [
+    pkgs.jq
+    pkgs.nix-fast-build
+  ];
+  text = ''
+    set -euo pipefail
+
+    ROOT="${flakeSrc}"
+    SYSTEM="$(nix eval --raw --impure --expr builtins.currentSystem)"
+    FLAKE_REF="path:$ROOT#checks.$SYSTEM"
+    RESULT="$(mktemp /tmp/${name}-result.XXXXXX.json)"
+    LOG="$(mktemp /tmp/${name}.XXXXXX.log)"
+    trap 'rm -f "$RESULT"' EXIT
+
+    ci_active() {
+      case "''${CI:-}" in
+        0|false|False|FALSE|"") return 1 ;;
+        *) return 0 ;;
+      esac
+    }
+
+    NFB_ARGS=(
+      --no-nom
+      --no-link
+      --flake "$FLAKE_REF"
+      --result-format json
+      --result-file "$RESULT"
+    )
+
+    set +e
+    if ci_active; then
+      nix-fast-build "''${NFB_ARGS[@]}" "$@" 2>&1 | tee "$LOG"
+      EXIT=''${PIPESTATUS[0]}
+      TRUNC_N=0
+    else
+      nix-fast-build "''${NFB_ARGS[@]}" "$@" >"$LOG" 2>&1
+      EXIT=$?
+      TRUNC_N=200
+    fi
+    set -e
+
+    if [[ ! -s "$RESULT" ]]; then
+      echo "status: error"
+      echo "exit: $EXIT"
+      echo "log: $LOG"
+      echo "root: $ROOT"
+      echo "flake: $FLAKE_REF"
+      echo
+      echo "error: nix-fast-build produced no JSON result file"
+      if [[ -s "$LOG" ]]; then
+        echo "log_tail:"
+        tail -n 40 "$LOG" | sed 's/^/  /'
+      fi
+      if [[ -n "$EXIT" ]]; then
+        exit "$EXIT"
+      fi
+      exit 1
+    fi
+
+    cp "$RESULT" "$LOG.json"
+
+    jq -r --argjson exit "$EXIT" --argjson trunc_n "$TRUNC_N" '
+      def trunc($n):
+        if $n == 0 then .
+        elif type == "string" and (length > $n) then .[0:$n-3] + "..."
+        else . end;
+      .results // [] as $r
+      | ($r | map(select(.type == "BUILD" or .type == "EVAL"))) as $jobs
+      | ($jobs | map(select(.success == true)) | length) as $ok
+      | ($jobs | map(select(.success != true))) as $bad
+      | [
+          (if $exit == 0 and ($bad | length) == 0 then "status: pass" else "status: fail" end),
+          "exit: \($exit)",
+          "summary:",
+          "  passed: \($ok)",
+          "  failed: \($bad | length)",
+          (
+            if ($bad | length) > 0 then
+              (["", "failures:"] + ($bad | map(
+                "  - \(.type) \(.attr)" +
+                (if .error == null or .error == "" then "" else ": \(.error | tostring | trunc($trunc_n))" end)
+              )))
+            else [] end
+          )
+        ]
+      | flatten
+      | .[]
+    ' "$RESULT"
+
+    echo "root: $ROOT"
+    echo "flake: $FLAKE_REF"
+    echo "log: $LOG"
+    echo "json: $LOG.json"
+    echo "hint: inspect json/log only if the summary is insufficient"
+
+    if [[ $EXIT -ne 0 ]]; then
+      exit "$EXIT"
+    fi
+    if jq -e '[.results[]? | select((.type == "BUILD" or .type == "EVAL") and (.success != true))] | length == 0' "$RESULT" >/dev/null; then
+      exit 0
+    fi
+    exit 1
+  '';
+}

--- a/nix/modules/home/development.nix
+++ b/nix/modules/home/development.nix
@@ -128,7 +128,7 @@ in {
 
   home.packages = with pkgs;
     [
-      unstable.antigravity-fhs
+      unstable.antigravity-ide-fhs
       unstable.code-cursor-fhs
       gh
       nil

--- a/nix/modules/nixos/base.nix
+++ b/nix/modules/nixos/base.nix
@@ -46,11 +46,11 @@
     ];
     substituters = [
       "https://nix-community.cachix.org"
-      "https://cache.garnix.io"
+      "https://niks3.actionable-internal.work"
     ];
     trusted-public-keys = [
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-      "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
+      "actionable-niks3:A3EpGS6+W9zj0r6tY3KPoODoBRELq70j+dkbhhgi7aQ="
     ];
   };
 

--- a/nix/modules/profiles/bootstrap.nix
+++ b/nix/modules/profiles/bootstrap.nix
@@ -9,6 +9,7 @@
     {
       networking.hostId = "12345678";
       boot.supportedFilesystems = ["zfs"];
+      boot.zfs.forceImportRoot = false;
       system.stateVersion = "25.11";
     }
   ];

--- a/nix/modules/utils/github-runner.nix
+++ b/nix/modules/utils/github-runner.nix
@@ -1,14 +1,14 @@
 /*
-  GitHub Actions self-hosted runners: one NixOS container per GitHub owner.
+GitHub Actions self-hosted runners: one NixOS container per GitHub owner.
 
-  Each owner gets its own container and agenix PAT so tokens are not shared
-  across personal vs org boundaries. See github-runner.md for auth setup.
+Each owner gets its own container and agenix PAT so tokens are not shared
+across personal vs org boundaries. See github-runner.md for auth setup.
 
-    just es github_runner_<owner>
+  just es github_runner_<owner>
 
-  Token file must be exactly one line with no trailing newline.
+Token file must be exactly one line with no trailing newline.
 */
-top@{
+top @ {
   config,
   lib,
   pkgs,
@@ -99,11 +99,7 @@ top@{
         };
       };
 
-    config = {
-      pkgs,
-      lib,
-      ...
-    }: {
+    config = {pkgs, ...}: {
       imports = [userModule];
 
       system.stateVersion = top.config.system.stateVersion;

--- a/nix/packages/flake-check.nix
+++ b/nix/packages/flake-check.nix
@@ -1,0 +1,11 @@
+{
+  pkgs,
+  inputs,
+  ...
+}: let
+  flakeSrc = pkgs.lib.cleanSource inputs.self;
+in
+  import ../lib/flake-check-tier.nix {
+    inherit pkgs flakeSrc;
+    name = "flake-check";
+  }

--- a/nix/packages/node-bootstrap-iso.nix
+++ b/nix/packages/node-bootstrap-iso.nix
@@ -2,17 +2,28 @@
   inputs,
   flake,
   ...
-}:
-inputs.nixos-generators.nixosGenerate {
+}: let
   system = "x86_64-linux";
-  format = "iso";
-  modules = [
-    flake.modules.profiles.bootstrap
-    flake.modules.users.tghanken
-    {
-      networking.hostId = "12345678";
-      boot.supportedFilesystems = ["zfs"];
-      system.stateVersion = "25.11";
-    }
-  ];
-}
+  nixos = inputs.nixpkgs.lib.nixosSystem {
+    inherit system;
+    specialArgs = {inherit inputs flake;};
+    modules = [
+      (
+        {modulesPath, ...}: {
+          imports = ["${modulesPath}/installer/cd-dvd/iso-image.nix"];
+          isoImage.makeEfiBootable = true;
+          isoImage.makeUsbBootable = true;
+        }
+      )
+      flake.modules.profiles.bootstrap
+      flake.modules.users.tghanken
+      {
+        networking.hostId = "12345678";
+        boot.supportedFilesystems = ["zfs"];
+        boot.zfs.forceImportRoot = false;
+        system.stateVersion = "25.11";
+      }
+    ];
+  };
+in
+  nixos.config.system.build.isoImage


### PR DESCRIPTION
## Summary
- Remove garnix and add a self-hosted GitHub Actions `flake-check` workflow that runs `nix run .#flake-check`
- Add a `flake-check` package wrapping `nix-fast-build` over `checks.$SYSTEM` for garnix-equivalent coverage
- Replace garnix binary cache references with niks3 and move the weekly lockfile workflow to self-hosted NixOS runners
- Fix flake check issues: blueprint module imports, bootstrap ISO build without `nixos-generators`, renamed `antigravity-ide-fhs`, and treefmt on github-runner

## Test plan
- [x] `nix build .#flake-check`
- [x] `nix build .#checks.x86_64-linux.treefmt-check`
- [ ] CI `flake-check` job passes on self-hosted runner after merge