### PR TITLE
feat: use niks3-hook auto-upload daemon for runner cache uploads

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -332,6 +332,27 @@
         "type": "github"
       }
     },
+    "niks3": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1785750318,
+        "narHash": "sha256-CvvoST6XDlBg/tQmb1B9V9GobZGzxsUo6MIWozIsZ1M=",
+        "owner": "Mic92",
+        "repo": "niks3",
+        "rev": "fc678647fe3a600de549e1c78ec109be39495528",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "niks3",
+        "type": "github"
+      }
+    },
     "nix": {
       "inputs": {
         "flake-parts": "flake-parts",
@@ -595,6 +616,7 @@
         "flake-parts": "flake-parts_2",
         "home-manager": "home-manager",
         "llm-agents": "llm-agents",
+        "niks3": "niks3",
         "nix-fast-build": "nix-fast-build",
         "nixos-anywhere": "nixos-anywhere",
         "nixos-facter-modules": "nixos-facter-modules",
@@ -603,7 +625,7 @@
         "nixpkgs-lib": "nixpkgs-lib",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "systems": "systems",
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": "treefmt-nix_2"
       }
     },
     "systems": {
@@ -622,6 +644,27 @@
       }
     },
     "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "niks3",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785360170,
+        "narHash": "sha256-XE1lKgQ3eIO3E7zWryqcRsax+mYXod/5RHBn4YaR9YE=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "d1187f8bc71fb8aab02395869ec3f5c1920f75c0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,11 @@
       inputs.treefmt-nix.follows = "treefmt-nix";
     };
 
+    niks3 = {
+      url = "github:Mic92/niks3";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     llm-agents = {
       url = "github:numtide/llm-agents.nix";
       inputs.nixpkgs.follows = "nixpkgs-unstable";

--- a/nix/modules/utils/github-runner.md
+++ b/nix/modules/utils/github-runner.md
@@ -152,17 +152,15 @@ Runners pull from niks3 via the `services.github-runner-containers.niks3`
 substituter (enabled by default). Upload support is also on by default
 (`niks3.uploader.enable`).
 
-When the uploader is enabled, each runner job gets:
+When the uploader is enabled, the **host** nix-daemon runs the
+[`niks3-hook` auto-upload daemon](https://github.com/Mic92/niks3/wiki/Auto-Upload):
+`niks3-hook serve` queues paths over a unix socket and uploads in the
+background; every build triggers `niks3-hook send` via Nix's
+`post-build-hook`. This requires `shareNixStore` (the default) so runner jobs
+use the host daemon.
 
-- `niks3` on `PATH`
-- `NIKS3_SERVER` / `NIKS3_SERVER_URL` set to the upload server
-- `NIKS3_AUTH_TOKEN_FILE` pointing at the agenix secret
-- `~/.config/niks3/auth-token` symlinked to the same secret (for
-  `nix-fast-build` and `niks3-warm-intermediates`)
-
-Workflows no longer need a "Setup niks3 cache" step on self-hosted runners.
-They still need `NIKS3_SERVER` in job `env` if the flake entrypoint gates on
-it (e.g. seneschal's `flake-check`).
+Workflows do not need upload steps or `NIKS3_*` environment variables on
+self-hosted runners — builds are uploaded automatically after they finish.
 
 ### Upload token
 
@@ -174,6 +172,13 @@ just es niks3_upload_token
 ```
 
 Secret file: `encrypted/niks3_upload_token.age`
+
+After deploy, verify the daemon:
+
+```bash
+systemctl status niks3-auto-upload.socket
+journalctl -fu niks3-auto-upload.service
+```
 
 To disable uploads without removing the substituter:
 

--- a/nix/modules/utils/github-runner.nix
+++ b/nix/modules/utils/github-runner.nix
@@ -12,6 +12,7 @@ top @ {
   config,
   lib,
   pkgs,
+  inputs,
   ...
 }: let
   inherit (lib) types mkOption mkIf mkMerge listToAttrs nameValuePair optionalAttrs optionals unique groupBy mapAttrsToList;
@@ -72,10 +73,6 @@ top @ {
 
   mkOwnerContainer = owner: runners: let
     tokenFile = config.age.secrets.${secretNameForOwner owner}.path;
-    niks3TokenFile = config.age.secrets.${niks3UploadSecret}.path;
-    runnerPackages =
-      cfg.extraPackages
-      ++ optionals cfg.niks3.uploader.enable [pkgs.niks3];
   in {
     autoStart = true;
     ephemeral = false;
@@ -102,12 +99,6 @@ top @ {
         # Read-only so the container cannot replace the host's daemon socket.
         "/nix/var/nix/daemon-socket" = {
           hostPath = "/nix/var/nix/daemon-socket";
-          isReadOnly = true;
-        };
-      }
-      // optionalAttrs cfg.niks3.uploader.enable {
-        ${niks3TokenFile} = {
-          hostPath = niks3TokenFile;
           isReadOnly = true;
         };
       };
@@ -145,11 +136,6 @@ top @ {
         })
       ];
 
-      systemd.tmpfiles.rules = optionals cfg.niks3.uploader.enable [
-        "d /var/lib/github-runner/.config/niks3 0750 ${runnerUser} ${runnerUser} -"
-        "L+ /var/lib/github-runner/.config/niks3/auth-token - - - - ${niks3TokenFile}"
-      ];
-
       users.groups.docker = mkIf cfg.dockerSocket (
         mkIf (hostDockerGid != null) {
           gid = hostDockerGid;
@@ -167,22 +153,15 @@ top @ {
             enable = true;
             name = "${runner.owner}-${runner.repo}-${hostName}";
             url = runnerUrl runner;
-            extraPackages = runnerPackages;
+            extraPackages = cfg.extraPackages;
             user = runnerUser;
             group = runnerUser;
             tokenFile = tokenFile;
             replace = true;
             extraLabels = labels;
-            extraEnvironment = mkMerge [
-              (optionalAttrs cfg.shareNixStore {
-                NIX_REMOTE = "daemon";
-              })
-              (optionalAttrs cfg.niks3.uploader.enable {
-                NIKS3_SERVER = cfg.niks3.uploader.server;
-                NIKS3_SERVER_URL = cfg.niks3.uploader.server;
-                NIKS3_AUTH_TOKEN_FILE = niks3TokenFile;
-              })
-            ];
+            extraEnvironment = optionalAttrs cfg.shareNixStore {
+              NIX_REMOTE = "daemon";
+            };
             serviceOverrides = {
               PrivateUsers = false;
               RestrictNamespaces = false;
@@ -190,9 +169,7 @@ top @ {
               BindPaths =
                 (optionals cfg.dockerSocket ["/var/run/docker.sock"])
                 ++ (optionals cfg.shareNixStore ["/nix/var/nix/daemon-socket"]);
-              BindReadOnlyPaths =
-                (optionals cfg.shareNixStore ["/nix/store"])
-                ++ (optionals cfg.niks3.uploader.enable [niks3TokenFile]);
+              BindReadOnlyPaths = optionals cfg.shareNixStore ["/nix/store"];
             };
           })
         runners
@@ -200,6 +177,8 @@ top @ {
     };
   };
 in {
+  imports = [inputs.niks3.nixosModules.niks3-auto-upload];
+
   options.services.github-runner-containers = {
     enable = mkOption {
       type = types.bool;
@@ -286,14 +265,15 @@ in {
           type = types.bool;
           default = true;
           description = ''
-            Provide the niks3 CLI and upload credentials to runner jobs.
-            Requires encrypted/niks3_upload_token.age (see github-runner.md).
+            Upload runner builds to niks3 via the niks3-hook auto-upload daemon
+            (post-build-hook on the host nix-daemon). Requires
+            encrypted/niks3_upload_token.age and shareNixStore (see github-runner.md).
           '';
         };
         server = mkOption {
           type = types.str;
           default = niks3Substituter;
-          description = "niks3 server URL for uploads (`NIKS3_SERVER`).";
+          description = "niks3 server URL for the auto-upload daemon.";
         };
       };
     };
@@ -312,6 +292,10 @@ in {
           assertion = !cfg.dockerSocket || config.virtualisation.docker.enable;
           message = "services.github-runner-containers.dockerSocket requires virtualisation.docker.enable";
         }
+        {
+          assertion = !cfg.niks3.uploader.enable || cfg.shareNixStore;
+          message = "services.github-runner-containers.niks3.uploader requires shareNixStore (host nix-daemon post-build-hook)";
+        }
       ];
 
       # Host daemon performs substitutions when shareNixStore is on.
@@ -326,6 +310,12 @@ in {
           trusted-public-keys = [cfg.niks3.publicKey];
         })
       ];
+
+      services.niks3-auto-upload = mkIf cfg.niks3.uploader.enable {
+        enable = true;
+        serverUrl = cfg.niks3.uploader.server;
+        authTokenFile = config.age.secrets.${niks3UploadSecret}.path;
+      };
 
       age.secrets =
         listToAttrs (


### PR DESCRIPTION
## Summary
- Switch GitHub Actions runner niks3 uploads from per-job `niks3` CLI + `NIKS3_*` env vars to the host-level `niks3-hook` auto-upload daemon
- Add the `niks3` flake input and enable `services.niks3-auto-upload` on the host nix-daemon (post-build-hook + socket-activated `niks3-hook serve`)
- Remove runner-container upload plumbing (auth-token symlink, token bind mounts, upload env vars)

## Test plan
- [ ] `nix build .#nixosConfigurations.hercules.config.system.build.toplevel --dry-run` succeeds
- [ ] Deploy to hercules and verify `systemctl status niks3-auto-upload.socket`
- [ ] Run a self-hosted workflow build and confirm paths appear in niks3 (`journalctl -fu niks3-auto-upload.service`)