### PR TITLE
feat: ephemeral GitHub runners with per-repo num parallelism

### DIFF
--- a/docs/superpowers/specs/2026-08-05-github-runner-ephemeral-num-design.md
+++ b/docs/superpowers/specs/2026-08-05-github-runner-ephemeral-num-design.md
@@ -1,0 +1,48 @@
+# Design: ephemeral runners + `num` parallelism
+
+Approved: option A (list entries + optional `num`), Hercules `num = 4`.
+
+## Goal
+
+Keep `services.github-runner-containers` (per-owner containers, niks3, Docker
+socket). Adopt two reliability/scale defaults from github-nix-ci:
+
+1. `ephemeral = true` on every nixpkgs `services.github-runners` unit
+2. Per-repo `num` to spin N parallel runners
+
+## Interface
+
+```nix
+services.github-runner-containers.runners = [
+  { owner = "tghanken"; repo = "nixos-config"; num = 4; }
+  { owner = "tghanken"; repo = "seneschal"; num = 4; }
+  { owner = "actionable-work"; repo = "actionable"; num = 4; }
+];
+```
+
+- `num` defaults to `1` if omitted
+- Must be a positive integer
+
+## Naming
+
+For index `i` in `1..num` (zero-padded to 2 digits):
+
+| Field | Pattern | Example |
+|---|---|---|
+| GitHub runner name | `{owner}-{repo}-{hostname}-{ii}` | `tghanken-nixos-config-hercules-01` |
+| systemd / state key | `{owner}-{repo}-{ii}` (sanitized) | `tghanken-nixos_config-01` |
+
+Suffix is always present (including `num = 1`) so naming stays uniform.
+
+## Behavior
+
+- `replace = true` (unchanged) + `ephemeral = true`: each job/start gets a
+  fresh registration; avoids stale credentials after GitHub GC
+- Containers, PAT layout, labels (`nixos` + hostname), Docker, niks3 unchanged
+- Old non-suffixed runner names on GitHub can be deleted manually after deploy
+
+## Out of scope
+
+- Org-wide runners (`orgRunners`)
+- Switching to github-nix-ci
+- Label model changes (`runs-on` stays `[self-hosted, nixos, hercules]`)

--- a/nix/hosts/hercules/configuration.nix
+++ b/nix/hosts/hercules/configuration.nix
@@ -42,14 +42,17 @@
       {
         owner = "tghanken";
         repo = "nixos-config";
+        num = 4;
       }
       {
         owner = "tghanken";
         repo = "seneschal";
+        num = 4;
       }
       {
         owner = "actionable-work";
         repo = "actionable";
+        num = 4;
       }
     ];
     extraLabels = ["nixos"];

--- a/nix/modules/utils/github-runner.md
+++ b/nix/modules/utils/github-runner.md
@@ -7,9 +7,10 @@ Self-hosted runners for hercules (and any host that imports
 
 - **One NixOS container per GitHub owner** (`tghanken`, `actionable-work`, …)
 - **One agenix PAT per owner** — mounted only into that owner's container
-- **One `services.github-runners` unit per repository** inside the owner container
+- **`num` ephemeral `services.github-runners` units per repository** inside
+  the owner container (default `num = 1`)
 
-Example on hercules:
+Example on hercules (`num = 4` each):
 
 | Container | PAT secret | Repos |
 |---|---|---|
@@ -125,6 +126,26 @@ jobs:
 
 Do not add a redundant `linux` label.
 
+Runners are **ephemeral** (`ephemeral = true`): each job gets a fresh
+registration, which avoids stale credentials after GitHub deletes idle
+runners. GitHub runner names look like
+`tghanken-nixos-config-hercules-01` (zero-padded index).
+
+## Parallelism (`num`)
+
+Set `num` on a repo entry to register that many parallel runners (same
+labels, same PAT). Hercules uses `num = 4`.
+
+```nix
+services.github-runner-containers.runners = [
+  {
+    owner = "tghanken";
+    repo = "nixos-config";
+    num = 4;
+  }
+];
+```
+
 ## Deploy checklist
 
 1. Create the two fine-grained PATs with the scopes above
@@ -132,13 +153,18 @@ Do not add a redundant `linux` label.
 3. Deploy hercules
 4. Confirm containers: `machinectl list` → `github-runners-tghanken`, `github-runners-actionable_work`
 5. Confirm runners under each repo’s **Settings → Actions → Runners**
+   (expect `num` online runners per repo; remove any old unsuffixed names)
 
 ## Adding a repo
 
 ```nix
 services.github-runner-containers.runners = [
   # …
-  { owner = "tghanken"; repo = "new-repo"; }
+  {
+    owner = "tghanken";
+    repo = "new-repo";
+    num = 2;
+  }
 ];
 ```
 

--- a/nix/modules/utils/github-runner.nix
+++ b/nix/modules/utils/github-runner.nix
@@ -15,7 +15,7 @@ top @ {
   inputs,
   ...
 }: let
-  inherit (lib) types mkOption mkIf mkMerge listToAttrs nameValuePair optionalAttrs optionals unique groupBy mapAttrsToList;
+  inherit (lib) types mkOption mkIf mkMerge listToAttrs nameValuePair optionalAttrs optionals unique groupBy mapAttrsToList concatMap range;
   cfg = config.services.github-runner-containers;
 
   runnerUser = "github-runner";
@@ -24,10 +24,23 @@ top @ {
   sanitizeSecret = s: lib.replaceStrings ["-" "."] ["_" "_"] s;
   # nixos-containers disallow underscores in names
   sanitizeContainer = s: lib.replaceStrings ["_" "."] ["-" "-"] s;
+  # Poor man's zero-padding for indices up to 99 (matches github-nix-ci).
+  paddedNum = n:
+    if n < 10
+    then "0${builtins.toString n}"
+    else builtins.toString n;
   secretNameForOwner = owner: "github_runner_${sanitizeSecret owner}";
   containerNameForOwner = owner: "github-runners-${sanitizeContainer owner}";
-  runnerServiceName = runner: "${sanitizeSecret runner.owner}-${sanitizeSecret runner.repo}";
+  runnerServiceName = runner: index: "${sanitizeSecret runner.owner}-${sanitizeSecret runner.repo}-${paddedNum index}";
+  runnerGithubName = runner: index: "${runner.owner}-${runner.repo}-${hostName}-${paddedNum index}";
   runnerUrl = runner: "https://github.com/${runner.owner}/${runner.repo}";
+  # Expand each declaration into `num` concrete runner instances.
+  expandRunners = runners:
+    concatMap (
+      runner:
+        map (index: {inherit runner index;}) (range 1 runner.num)
+    )
+    runners;
 
   owners = unique (map (r: r.owner) cfg.runners);
   runnersByOwner = groupBy (r: r.owner) cfg.runners;
@@ -67,6 +80,14 @@ top @ {
         type = types.listOf types.str;
         default = [];
         description = "Extra labels for this runner (merged with module defaults).";
+      };
+      num = mkOption {
+        type = types.ints.positive;
+        default = 1;
+        description = ''
+          Number of parallel ephemeral runners to register for this repository.
+          Each instance gets a unique name suffix (`-01`, `-02`, …).
+        '';
       };
     };
   };
@@ -114,10 +135,13 @@ top @ {
 
       # Never run a container-local nix-daemon against the shared host socket —
       # that replaces the host socket and breaks Nix for everyone on the machine.
+      # With nix.enable=false, NixOS does not write /etc/nix/nix.conf, so the
+      # client CLI would lack experimental-features unless we set NIX_CONFIG.
       nix.enable = !cfg.shareNixStore;
       environment.systemPackages = optionals cfg.shareNixStore [pkgs.nix];
       environment.variables = optionalAttrs cfg.shareNixStore {
         NIX_REMOTE = "daemon";
+        NIX_CONFIG = "experimental-features = nix-command flakes";
       };
 
       nix.settings = mkMerge [
@@ -143,24 +167,31 @@ top @ {
       );
 
       services.github-runners = listToAttrs (
-        map (runner: let
+        map ({
+          runner,
+          index,
+        }: let
           labels =
             cfg.extraLabels
             ++ [hostName]
             ++ runner.extraLabels;
         in
-          nameValuePair (runnerServiceName runner) {
+          nameValuePair (runnerServiceName runner index) {
             enable = true;
-            name = "${runner.owner}-${runner.repo}-${hostName}";
+            name = runnerGithubName runner index;
             url = runnerUrl runner;
             extraPackages = cfg.extraPackages;
             user = runnerUser;
             group = runnerUser;
             tokenFile = tokenFile;
             replace = true;
+            ephemeral = true;
             extraLabels = labels;
             extraEnvironment = optionalAttrs cfg.shareNixStore {
               NIX_REMOTE = "daemon";
+              # Jobs inherit this; required because shareNixStore disables
+              # container nix.conf generation (nix.enable = false).
+              NIX_CONFIG = "experimental-features = nix-command flakes";
             };
             serviceOverrides = {
               PrivateUsers = false;
@@ -172,7 +203,7 @@ top @ {
               BindReadOnlyPaths = optionals cfg.shareNixStore ["/nix/store"];
             };
           })
-        runners
+        (expandRunners runners)
       );
     };
   };
@@ -191,6 +222,7 @@ in {
       default = [];
       description = ''
         Runners to register. Grouped by `owner` into one container each.
+        Each entry may set `num` (default 1) for parallel ephemeral runners.
         Each owner needs encrypted/github_runner_<owner>.age
         (hyphens/dots become underscores). See github-runner.md.
       '';
@@ -198,6 +230,7 @@ in {
         {
           owner = "tghanken";
           repo = "nixos-config";
+          num = 2;
         }
         {
           owner = "actionable-work";


### PR DESCRIPTION
## Summary

- Add `num` option to `services.github-runner-containers.runners` to register N parallel ephemeral runners per repository (zero-padded `-01`, `-02`, … suffixes)
- Set `ephemeral = true` on all nixpkgs `services.github-runners` units so each job gets a fresh registration and stale credentials are avoided after GitHub GC
- Scale Hercules to `num = 4` for nixos-config, seneschal, and actionable repos

## Test plan

- [ ] `nix flake check` passes
- [ ] Deploy to hercules and confirm 12 runners register on GitHub (4 per repo × 3 repos)
- [ ] Run a workflow on each repo and verify `runs-on: [self-hosted, nixos, hercules]` picks up a runner
- [ ] Delete old non-suffixed runner names on GitHub after deploy